### PR TITLE
Make human interaction optional

### DIFF
--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -169,8 +169,8 @@ class BaseAgent:
         - Once you have the information or need to respond, use contact_human to reply to the user
         - Don't explain your internal process, just respond naturally in your role
 
-        2. Agent Messages (Pending Questions):
-        - These appear in the format "Pending questions: <AgentType>: <question>"
+        2. Agent Messages (Pending Messages):
+        - These appear in the format "Pending messages: <AgentType>: <message>"
         - If you can answer using available context, respond using chat_with_agent to that agent
         - If you need to ask your user, use contact_human and then inform the agent you're getting the information
         - When your user later provides the answer, send it to the requesting agent using chat_with_agent
@@ -224,13 +224,9 @@ class BaseAgent:
         if message:
             session_messages.append({"content": message, "role": "user"})
 
-        queue_message = ""
-        if self._queue:
-            queue_message = f"Pending questions: {self._queue.pop(0)}"
-
         # get the last 7 messages from all other agents' sessions 
         other_agent_messages = self._agent_manager.get_agent_messages(self.TYPE, num_messages=7)
-        message_full = f"{queue_message}\n{other_agent_messages}"
+        message_full = f"{other_agent_messages}"
         if message:
             message_full += f"\n User: {message}"
 
@@ -339,7 +335,7 @@ class BaseAgent:
         current_messages = session_messages.copy()
 
         if message:
-            queue_message = f"Pending questions: {message}"
+            queue_message = f"Pending messages: {message}"
 
         print(f"Queue message for {self.TYPE}: {queue_message}")
 

--- a/mahilo/templates/scenario_911/dispatcher.py
+++ b/mahilo/templates/scenario_911/dispatcher.py
@@ -7,7 +7,9 @@ You are a 911 emergency dispatcher, the critical first point of contact for emer
 1. Answering emergency calls and communicating calmly with callers who may be in distress.
 2. Quickly assessing the nature and severity of the emergency.
 3. Calling the chat_with_agent tool to ask the right agents for information or help.
-4. Providing pre-arrival instructions to callers when necessary (e.g., CPR guidance, safety instructions).
+4. Calling the contact_human function to talk to your human when you need to send some information to them or get new information from them.
+5. Providing pre-arrival instructions to callers when necessary (e.g., CPR guidance, safety instructions).
+6. Be responsible. Think about what you are saying to the other agents and how you respond to them.
 
 Key points to remember:
 - This is just a test scenario. No one is really calling you or is in an emergency.

--- a/mahilo/templates/scenario_911/police.py
+++ b/mahilo/templates/scenario_911/police.py
@@ -5,15 +5,16 @@ POLICE_PROXY_PROMPT = """
 You are a police proxy agent. Your role is to communicate with real police officers and relay law enforcement advice and information to the emergency dispatcher agent. 
 
 Key points to remember:
-1. You are not a real police officer. You are a proxy agent that communicates with real police officers. Don't respond to the dispatcher directly.
+1. You are not a real police officer. You are a proxy agent that communicates with real police officers.
 2. You do not communicate directly with civilians or emergency callers. Your interactions are with real police officers and the emergency dispatcher agent.
 3. You are in conversation with a real police officer. Anything that a real police officer should answer, you should output and ask them.
 4. When the police officer asks a question about the situation or caller, you should use the chat_with_agent tool to ask the emergency dispatcher agent for information.
 5. If what the police asks is already in the context, don't ask again.
-6. Don't assume the role of a police officer yourself. You are a proxy agent, you should talk to the real police officer on behalf of the emergency dispatcher agent.
-7. Messages you receive are either from real police officers or the emergency dispatcher agent seeking law enforcement-related advice or action.
-8. Use appropriate law enforcement terminology with real officers, but provide clear explanations for the dispatcher.
-9. You should relay any info that the dispatcher has requested to the police officer. Like how far is the police, etc. Relay this info back to the dispatcher as soon as you get it.
+6. When there is a request for police from the dispatcher or any situation that needs the police's attention, use the contact_human function to talk to your police human immediately.
+7. Don't assume the role of a police officer yourself. You are a proxy agent, you should talk to the real police officer on behalf of the emergency dispatcher agent when the need arises.
+8. Messages you receive are either from real police officers or the emergency dispatcher agent seeking law enforcement-related advice or action.
+9. Use appropriate law enforcement terminology with real officers, but provide clear explanations for the dispatcher.
+10. You should relay any info that the dispatcher has requested to the police officer. Like how far is the police, etc. Relay this info back to the dispatcher as soon as you get it.
 
 Example:
 1. Receive from dispatcher: "Reported break-in at 123 Main St. Please advise on police response."


### PR DESCRIPTION
- Added a new function that is called when a message pops up in the queue for an agent
- This replaces the older paradigm of just dumping queue messages in the agent-human websocket connection.
- Now this function is called first, and the agent then decides whether to call the human or talk to another agent by itself.
- This makes it easier and more natural to work with multi-agent systems and enables use cases where humans are not needed.

In short, this makes mahilo flexible to be used for a range of new use cases by taking away the requirement of a human to be associated with an agent.