### PR TITLE
Ability to add and modify custom tools 

### DIFF
--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -170,16 +170,22 @@ class BaseAgent:
                 "'chat_with_agent' and 'contact_human' are predefined tools and can't be modified."
             )
         self._custom_tools.append(tool)
+        print(f"Tool '{tool_name}' added to toolkit")
 
     def remove_tool(self, tool_name: str) -> None:
         """Remove a tool from the agent's toolkit by name.
         Note: Cannot remove base tools."""
         if tool_name in ["chat_with_agent", "contact_human"]:
-            raise ValueError(
-                f"Tool with name '{tool_name}' cannot be removed. It is a base tool."
-            )
-        self._custom_tools = [t for t in self._custom_tools 
-                            if t.get("function", {}).get("name") != tool_name]
+            raise ValueError(f"Cannot remove base tool '{tool_name}'")
+            
+        # Find tool index to avoid multiple list traversals
+        tool_names = [t.get("function", {}).get("name") for t in self._custom_tools]
+        try:
+            tool_index = tool_names.index(tool_name)
+            self._custom_tools.pop(tool_index)
+            print(f"Tool '{tool_name}' removed from toolkit")
+        except ValueError:
+            raise ValueError(f"Tool '{tool_name}' not found in toolkit")
 
     def prompt_message(self) -> str:
         """Return a prompt message for the agent."""

--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -372,6 +372,7 @@ class BaseAgent:
         while tool_calls:
             available_functions = {
                 "chat_with_agent": self.chat_with_agent,
+                **self._custom_functions  # Add custom functions to available functions
             }
             
             for tool_call in tool_calls:

--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -50,6 +50,11 @@ class BaseAgent:
         self.description = description
         self.can_contact = can_contact
         self.short_description = short_description
+        # validate if the tool names supplied are not already taken
+        if tools:
+            for tool in tools:
+                if tool["function"]["name"] in ["chat_with_agent", "contact_human"]:
+                    raise ValueError(f"Tool with name '{tool['function']['name']}' cannot be used as it is a base tool.")
         self._custom_tools = tools or []
 
     # make a function that returns the list of agents with their descriptions that this agent can contact

--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -153,8 +153,12 @@ class BaseAgent:
 
     def add_tool(self, tool: Dict[str, Any]) -> None:
         """Add a new tool to the agent's toolkit."""
+        # Validate tool has required properties
+        if "function" not in tool or "name" not in tool["function"]:
+            raise ValueError("Tool must have a 'function' property with a 'name' field")
+            
         # Check if tool with same name already exists
-        tool_name = tool.get("function", {}).get("name")
+        tool_name = tool["function"]["name"]
         if any(t.get("function", {}).get("name") == tool_name for t in self.tools):
             raise ValueError(
                 f"Tool with name '{tool_name}' already exists. Please note that "

--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -382,7 +382,7 @@ class BaseAgent:
                     function_response = function_to_call(**function_args)
                 except Exception as e:
                     print(f"Error calling function {function_name}: {e}")
-                    pass
+                    continue
 
                 func_resp = ""
                 # make one str from the function_response list of str


### PR DESCRIPTION
You can now define custom tools for your mahilo agent using a tool config (an OpenAI tool spec + function reference).
- pass it through the constructor during initialization
- add it afterwards using `add_tool`
- remove a tool using `remove_tool` which gives you the tool config as output and can be used to add it back later

There's also validation in place that ensures
- a tool config has both the tool and the function reference
- the function you pass is callable and has a str or List[str] as return type. This is done to encourage returning some message that can be used by the model to inform the user of the function call.