### PR TITLE
Introduce agent name as primary identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When the code above is run, it starts a websocket server on localhost (unless so
 For example, to do that for one agent, you can run the following command in a separate terminal (from the root of this repo):
 
 ```
-python mahilo/client.py --url http://localhost:8000 --agent-type emergency_dispatcher
+python mahilo/client.py --url http://localhost:8000 --agent-name emergency_dispatcher
 ```
 
 This would then allow you to talk to the emergency dispatcher agent. If you pass the `--voice` flag, you would be able to talk to the agent using voice.
@@ -150,14 +150,14 @@ More information on the features can be found in the [Detailed Features](#detail
    For each of the agents in the system, you can spin up a client to connect to the server.
    ```
    cd mahilo
-   python client.py --url http://localhost:8000 --agent-type your_agent_type
+   python client.py --url http://localhost:8000 --agent-name your_agent_name
    ```
    Run this command in separate terminals for each of the agents and you can then start talking with them.
 
    If you want to use the voice feature, you can run the same command with the `--voice` flag:
    ```
    cd mahilo
-   python client.py --url http://localhost:8000 --agent-type your_agent_type --voice
+   python client.py --url http://localhost:8000 --agent-name your_agent_name --voice
    ```
 
 
@@ -177,14 +177,14 @@ More information on the features can be found in the [Detailed Features](#detail
 
 4. Connect to your server using the CLI client:
    ```
-   python mahilo/client.py --url http://localhost:8000 --agent-type your_agent_type
+   python mahilo/client.py --url http://localhost:8000 --agent-name your_agent_name
    ```
    You can connect to the same server using multiple clients to test the system with multiple users. This is useful for testing the system in a real-world scenario where multiple agents need to coordinate their actions.
 
    If you want to use the voice feature, you can run the same command with the `--voice` flag:
    ```
    cd mahilo
-   python client.py --url http://localhost:8000 --agent-type your_agent_type --voice
+   python client.py --url http://localhost:8000 --agent-name your_agent_name --voice
    ```
 
 > [!TIP]
@@ -207,7 +207,7 @@ More information on the features can be found in the [Detailed Features](#detail
 - [Easy-to-use agent definition system](#easy-to-use-agent-definition-system)
 - [WebSocket-based real-time communication](#websocket-based-real-time-communication)
 - [Flexible communication patterns: peer-to-peer and hierarchical (or centralized)](#flexible-communication-patterns-peer-to-peer-and-hierarchical-or-centralized)
-- [Flexible agent manager for handling multiple agent types](#flexible-agent-manager-for-handling-multiple-agent-types)
+- [Flexible agent manager for handling multiple agent types](#flexible-agent-manager-for-handling-multiple-agent-names)
 - [Session management for persistent conversations](#session-management-for-persistent-conversations)
 
 ### Human-in-the-Loop

--- a/examples/dispatcher/README.md
+++ b/examples/dispatcher/README.md
@@ -34,7 +34,7 @@ This is a simple multi-agent dispatcher that can be used to dispatch tasks to mu
 
 5. Connect to your server using the CLI client:
    ```
-   python client.py --url http://localhost:8000 --agent-type dispatcher
+   python client.py --url http://localhost:8000 --agent-name dispatcher
    ```
    You can connect to the same server using multiple clients to test the system in a real-world scenario where multiple agents need to coordinate their actions.
 

--- a/examples/health_emergency/README.md
+++ b/examples/health_emergency/README.md
@@ -41,13 +41,13 @@ An image showing how the agents that talk to the humans add to their productivit
 
 5. Connect to your server using the CLI client:
    ```
-   python client.py --url http://localhost:8000 --agent-type medical_advisor
+   python client.py --url http://localhost:8000 --agent-name medical_advisor
    ```
 
    You can connect to the same server using multiple clients to interact with different agents in the system. For example:
    ```
-   python client.py --url http://localhost:8000 --agent-type logistics_coordinator
-   python client.py --url http://localhost:8000 --agent-type public_communications_director
+   python client.py --url http://localhost:8000 --agent-name logistics_coordinator
+   python client.py --url http://localhost:8000 --agent-name public_communications_director
    ```
 
 > [!TIP]

--- a/examples/real_estate_management/buyer_agent.py
+++ b/examples/real_estate_management/buyer_agent.py
@@ -96,9 +96,10 @@ tools = [
 ]
 
 class BuyerAgent(BaseAgent):
-    def __init__(self, buyer_preferences: str, type: str = "buyer_agent", can_contact: List[str] = []):
+    def __init__(self, buyer_preferences: str, name: str = None, can_contact: List[str] = []):
         super().__init__(
-            type=type,
+            name=name,
+            type="buyer_agent",
             description=BUYER_AGENT_PROMPT + "\n\n" + buyer_preferences,
             short_description=BUYER_AGENT_SHORT_DESCRIPTION,
             tools=tools,

--- a/examples/real_estate_management/buyer_agent.py
+++ b/examples/real_estate_management/buyer_agent.py
@@ -6,11 +6,12 @@ BUYER_AGENT_PROMPT = """
 You are a professional real estate buyer's agent. Your role is to help buyers find their ideal property. Your responsibilities include:
 
 1. Understanding buyer preferences and requirements clearly
-2. Searching for properties that match the buyer's criteria using the search_properties tool
-3. Checking the buyer's availability using the get_available_dates tool
-4. Communicating with seller agents using chat_with_agent tool
-5. Coordinating property visits between buyers and sellers after matching dates
-6. Using contact_human function to communicate with your buyer only when needed
+2. Searching for properties that match the buyer's criteria using the search_properties tool.
+3. Waiting for the buyer to confirm properties before proceeding to talk to the seller agents.
+4. Checking the buyer's availability using the get_available_dates tool
+5. Communicating with seller agents using chat_with_agent tool
+6. Coordinating property visits between buyers and sellers after matching dates. DON'T ASK FOR TIME, ONLY FIX THE DATE.
+7. Using contact_human function to communicate with your buyer only when needed.
 
 Key points to remember:
 - Be responsible, don't repeat sentences, don't ask the same question multiple times, and don't waste words. For example, don't ask for the dates again if you already have them.
@@ -24,10 +25,9 @@ Key points to remember:
   * Be professional and courteous
   * Ask relevant questions about the property
   * Inquire about specific requirements your buyer has mentioned
-  * Coordinate visit schedules efficiently
+  * Coordinate visit schedules efficiently. Don't worry about the time of visit. only fix the date.
 - Only contact your human (buyer) when necessary:
   * To confirm property selections
-  * To verify availability for visits
   * To get additional preferences or requirements
   * To handle scheduling conflicts
 

--- a/examples/real_estate_management/run_server.py
+++ b/examples/real_estate_management/run_server.py
@@ -8,13 +8,13 @@ manager = AgentManager()
 
 # create the agents
 buyer_preferences = "Buyer preferences: I am looking for a 2BHK in Koramangala or Indiranagar with good schools and hospitals nearby."
-buyer_agent = BuyerAgent(buyer_preferences=buyer_preferences, can_contact=["seller_agent_1", "seller_agent_2"])
+buyer_agent = BuyerAgent(buyer_preferences=buyer_preferences, name="buyer_agent", can_contact=["seller_agent_1", "seller_agent_2"])
 
 seller_preferences_1 = "Seller preferences: I prefer to sell my property to a young family with children. I want that when they are living in the property, they should be inside the property by 9pm."
-seller_agent_1 = SellerAgent(type="seller_agent_1", seller_preferences=seller_preferences_1, can_contact=["buyer_agent"])
+seller_agent_1 = SellerAgent(seller_preferences=seller_preferences_1, name="seller_agent_1", can_contact=["buyer_agent"])
 
 seller_preferences_2 = "Seller preferences: I prefer to sell my property to bachelors. I don't care when they get home in the night."
-seller_agent_2 = SellerAgent(type="seller_agent_2", seller_preferences=seller_preferences_2, can_contact=["buyer_agent"])
+seller_agent_2 = SellerAgent(seller_preferences=seller_preferences_2, name="seller_agent_2", can_contact=["buyer_agent"])
 
 # register the agents to the manager
 manager.register_agent(buyer_agent)

--- a/examples/real_estate_management/seller_agent.py
+++ b/examples/real_estate_management/seller_agent.py
@@ -21,10 +21,9 @@ Key points to remember:
   * Be responsive and professional
   * Answer all queries about the property honestly
   * Be clear about any rules or restrictions
-  * Coordinate visit schedules efficiently
+  * Coordinate visit schedules efficiently. Don't worry about the time of visit. only fix the date.
 - Only contact your human (seller) when necessary:
   * To verify specific property details
-  * To confirm availability for visits
   * To handle scheduling conflicts
   * To discuss special requests or exceptions
 - If a scheduling conflict arises:

--- a/examples/real_estate_management/seller_agent.py
+++ b/examples/real_estate_management/seller_agent.py
@@ -59,9 +59,10 @@ tools = [
 ]
 
 class SellerAgent(BaseAgent):
-    def __init__(self, type: str, seller_preferences: str, can_contact: List[str] = []):
+    def __init__(self, seller_preferences: str, name: str = None, can_contact: List[str] = []):
         super().__init__(
-            type=type,
+            name=name,
+            type="seller_agent",
             description=SELLER_AGENT_PROMPT + "\n\n" + seller_preferences,
             short_description=SELLER_AGENT_SHORT_DESCRIPTION,
             tools=tools,

--- a/examples/story_weavers/run_server.py
+++ b/examples/story_weavers/run_server.py
@@ -14,7 +14,7 @@ def main(agent_names):
     # create and register agents
     agents = []
     for name in agent_names:
-        agent = StoryWeaverAgent(type=f'{name}_weaver')
+        agent = StoryWeaverAgent(name=f'{name}_weaver')
         manager.register_agent(agent)
         agents.append(agent)
     

--- a/mahilo/agent_manager.py
+++ b/mahilo/agent_manager.py
@@ -12,15 +12,14 @@ class AgentManager:
 
     def register_agent(self, agent: BaseAgent) -> None:
         """Register an agent with the AgentManager."""
-        # if the agent is already registered, raise an error
-        if agent.TYPE in self.agents:
-            raise ValueError(f"Agent of type {agent.TYPE} is already registered.")
+        if agent.name in self.agents:
+            raise ValueError(f"Agent with name {agent.name} is already registered.")
         agent._agent_manager = self
-        self.agents[agent.TYPE] = agent
+        self.agents[agent.name] = agent
 
-    def get_agent(self, agent_type: str) -> BaseAgent:
-        """Return the agent of the given type."""
-        return self.agents.get(agent_type)
+    def get_agent(self, agent_name: str) -> BaseAgent:
+        """Return the agent of the given name."""
+        return self.agents.get(agent_name)
     
     def get_all_agent_types(self) -> List[str]:
         """Return a list of all registered agent types."""
@@ -30,14 +29,14 @@ class AgentManager:
         """Return a list of all registered agents."""
         return list(self.agents.values())
 
-    def is_agent_registered(self, agent_type: str) -> bool:
-        """Check if an agent of the given type is registered."""
-        return agent_type in self.agents
+    def is_agent_registered(self, agent_name: str) -> bool:
+        """Check if an agent of the given name is registered."""
+        return agent_name in self.agents
 
-    def unregister_agent(self, agent_type: str) -> None:
-        """Unregister the agent of the given type."""
-        if agent_type in self.agents:
-            del self.agents[agent_type]
+    def unregister_agent(self, agent_name: str) -> None:
+        """Unregister the agent of the given name."""
+        if agent_name in self.agents:
+            del self.agents[agent_name]
 
     def unregister_all_agents(self) -> None:
         """Unregister all agents."""
@@ -45,20 +44,17 @@ class AgentManager:
 
     def get_agent_types_with_description(self) -> Dict[str, str]:
         """Return a list of all registered agent types with their descriptions."""
-        # for the description, we only want the short description
-        # the short description first 0 words
-        return {agent.TYPE: agent.short_description for agent in self.agents.values()}
+        return {agent.name: agent.short_description for agent in self.agents.values()}
     
     # get last 3 messages from all agents' sessions except the current agent.
-    def get_agent_messages(self, agent_type: str, num_messages: int = 7) -> str:
+    def get_agent_messages(self, agent_name: str, num_messages: int = 7) -> str:
         """Return messages from all agents' sessions except the current agent."""
         messages = []
         for agent in self.agents.values():
-            if agent.TYPE != agent_type and agent._session:
+            if agent.name != agent_name and agent._session:
                 agent_messages = agent._session.get_last_n_messages(num_messages)
                 if agent_messages:  # Only add if there are messages
-                    agent_name = agent.TYPE
-                    context = f"\nOther Conversations: {agent_name}\n"
+                    context = f"\nOther Conversations: {agent.name}\n"
                     context += "\n".join([
                         f"{message['role']}: {message['content']}" 
                         for message in agent_messages
@@ -69,7 +65,7 @@ class AgentManager:
         
     def populate_can_contact_for_agents(self) -> None:
         """Populate the can_contact list for all agents."""
-        # if the can_contact is empty, set it to all agents
+        # if the can_contact is empty, set it to all agent names
         for agent in self.agents.values():
             if not agent.can_contact:
-                agent.can_contact = self.get_all_agent_types()
+                agent.can_contact = list(self.agents.keys())

--- a/mahilo/client.py
+++ b/mahilo/client.py
@@ -9,9 +9,9 @@ import json
 import threading
 
 class Client:
-    def __init__(self, url: str, agent_type: Optional[str] = None, voice: bool = False):
+    def __init__(self, url: str, agent_name: Optional[str] = None, voice: bool = False):
         self.base_url = url
-        self.agent_type = agent_type
+        self.agent_name = agent_name
         self.websocket: Optional[websockets.WebSocketClientProtocol] = None
         self.audio = pyaudio.PyAudio()
         self.stream = None
@@ -21,9 +21,9 @@ class Client:
 
     async def connect(self):
         if self.voice:
-            websocket_url = f"ws://{self.base_url.split('://')[-1]}/ws/voice-stream/{self.agent_type}"
+            websocket_url = f"ws://{self.base_url.split('://')[-1]}/ws/voice-stream/{self.agent_name}"
         else:
-            websocket_url = f"ws://{self.base_url.split('://')[-1]}/ws/{self.agent_type or 'main'}"
+            websocket_url = f"ws://{self.base_url.split('://')[-1]}/ws/{self.agent_name or 'main'}"
         print(f"Connecting to {websocket_url}")
         self.websocket = await websockets.connect(websocket_url)
         asyncio.create_task(self._listen())
@@ -44,11 +44,11 @@ class Client:
                         rich.print(f"[bold green]🎵  Received audio data[/bold green] ([italic]{len(audio_data)} bytes[/italic])")
                         self._play_audio(audio_data)
                     else:
-                        rich.print(f"[bold magenta]{self.agent_type or 'Agent'}:[/bold magenta] {message}")
+                        rich.print(f"[bold magenta]{self.agent_name or 'Agent'}:[/bold magenta] {message}")
                 else:
-                    rich.print(f"[bold magenta]{self.agent_type or 'Agent'}:[/bold magenta] {message}")
+                    rich.print(f"[bold magenta]{self.agent_name or 'Agent'}:[/bold magenta] {message}")
         except websockets.ConnectionClosed:
-            rich.print(f"[bold red]⚠️  Connection to {self.agent_type} closed[/bold red]")
+            rich.print(f"[bold red]⚠️  Connection to {self.agent_name} closed[/bold red]")
 
     async def send_message(self, message: str):
         if self.websocket:
@@ -110,7 +110,7 @@ async def run_client(client: Client):
             message = await asyncio.get_event_loop().run_in_executor(
                 None, 
                 input,
-                f"Enter message for {client.agent_type or 'main agent'} (or 'quit' to exit): "
+                f"Enter message for {client.agent_name or 'main agent'} (or 'quit' to exit): "
             )
             if message.lower() == 'quit':
                 break
@@ -119,11 +119,11 @@ async def run_client(client: Client):
 
 @click.command()
 @click.option('--url', default='http://localhost:8000', help='Server URL')
-@click.option('--agent-type', required=True, help='Agent type to connect to')
+@click.option('--agent-name', required=True, help='Name of the agent to connect to')
 @click.option('--voice', is_flag=True, help='Enable voice', default=False)
-def cli(url: str, agent_type: Optional[str], voice: bool):
+def cli(url: str, agent_name: Optional[str], voice: bool):
     """CLI for connecting to the multi-agent server."""
-    client = Client(url, agent_type, voice)
+    client = Client(url, agent_name, voice)
     asyncio.run(run_client(client))
 
 if __name__ == "__main__":

--- a/mahilo/session.py
+++ b/mahilo/session.py
@@ -19,15 +19,15 @@ class Session:
     - User messages
     - Agent messages
     """
-    def __init__(self, agent_type: str, server_id: str = None):
-        self.agent_id = agent_type
+    def __init__(self, agent_name: str, server_id: str = None):
+        self.agent_name = agent_name
         self.messages: List[Dict[str, str]] = []
         
         # Create a unique directory for each server instance
         self.server_dir = f"sessions/{server_id}" if server_id else "sessions"
         Path(self.server_dir).mkdir(parents=True, exist_ok=True)
         
-        self.file_path = os.path.join(self.server_dir, f"{agent_type}.json")
+        self.file_path = os.path.join(self.server_dir, f"{agent_name}.json")
         self.load_messages()
 
     def load_messages(self):

--- a/mahilo/templates/centralized/dispatcher.py
+++ b/mahilo/templates/centralized/dispatcher.py
@@ -29,5 +29,6 @@ class Dispatcher(BaseAgent):
     def __init__(self):
         super().__init__(
             type='dispatcher',
+            name='dispatcher',
             description=DISPATCHER_PROMPT,
         )

--- a/mahilo/templates/centralized/mold_specialist.py
+++ b/mahilo/templates/centralized/mold_specialist.py
@@ -32,5 +32,6 @@ class MoldSpecialist(BaseAgent):
     def __init__(self):
         super().__init__(
             type='mold_specialist',
+            name='mold_specialist',
             description=MOLDSPECIALIST_PROMPT,
         )   

--- a/mahilo/templates/centralized/plumber.py
+++ b/mahilo/templates/centralized/plumber.py
@@ -31,5 +31,6 @@ class Plumber(BaseAgent):
     def __init__(self):
         super().__init__(
             type='plumber',
+            name='plumber',
             description=PLUMBER_PROMPT,
         )

--- a/mahilo/templates/peer2peer/logistics_coordinator.py
+++ b/mahilo/templates/peer2peer/logistics_coordinator.py
@@ -25,5 +25,6 @@ class LogisticsCoordinator(BaseAgent):
     def __init__(self):
         super().__init__(
             type='logistics_coordinator',
+            name='logistics_coordinator',
             description=LOGISTICS_COORDINATOR_PROMPT,
         )

--- a/mahilo/templates/peer2peer/medical_advisor.py
+++ b/mahilo/templates/peer2peer/medical_advisor.py
@@ -24,5 +24,6 @@ class MedicalAdvisor(BaseAgent):
     def __init__(self):
         super().__init__(
             type='medical_advisor',
+            name='medical_advisor',
             description=MEDICAL_ADVISOR_PROMPT,
         )

--- a/mahilo/templates/peer2peer/public_communications_director.py
+++ b/mahilo/templates/peer2peer/public_communications_director.py
@@ -26,5 +26,6 @@ class PublicCommunicationsDirector(BaseAgent):
     def __init__(self):
         super().__init__(
             type='public_communications_director',
+            name='public_communications_director',
             description=PUBLIC_COMMUNICATIONS_DIRECTOR_PROMPT,
         )

--- a/mahilo/templates/scenario_911/dispatcher.py
+++ b/mahilo/templates/scenario_911/dispatcher.py
@@ -36,6 +36,7 @@ class EmergencyDispatcher(BaseAgent):
     def __init__(self):
         super().__init__(
             type='emergency_dispatcher',
+            name='emergency_dispatcher',
             description=EMERGENCY_DISPATCHER_PROMPT,
             short_description=EMERGENCY_DISPATCHER_SHORT_DESCRIPTION,
         )

--- a/mahilo/templates/scenario_911/medic.py
+++ b/mahilo/templates/scenario_911/medic.py
@@ -32,6 +32,7 @@ class MedicalProxyAgent(BaseAgent):
     def __init__(self):
         super().__init__(
             type='medical_proxy',
+            name='medical_proxy',
             description=MEDICAL_PROXY_PROMPT,
             can_contact=["emergency_dispatcher"],
             short_description=MEDICAL_PROXY_SHORT_DESCRIPTION,

--- a/mahilo/templates/scenario_911/police.py
+++ b/mahilo/templates/scenario_911/police.py
@@ -30,6 +30,7 @@ class PoliceProxyAgent(BaseAgent):
     def __init__(self):
         super().__init__(
             type='police_proxy',
+            name='police_proxy',
             description=POLICE_PROXY_PROMPT,
             can_contact=["emergency_dispatcher"],
             short_description=POLICE_PROXY_SHORT_DESCRIPTION,

--- a/mahilo/templates/story_weavers/story_weaver_agent.py
+++ b/mahilo/templates/story_weavers/story_weaver_agent.py
@@ -71,9 +71,10 @@ Remember: Ask one question at a time to help story build naturally bizzare, neve
 STORY_WEAVER_SHORT_DESCRIPTION = "An imaginative guide helping humans create wild stories that occasionally crash into each other."
 
 class StoryWeaverAgent(BaseAgent):
-    def __init__(self, type: str = 'story_weaver'):
+    def __init__(self, name: str = None, type: str = 'story_weaver'):
         super().__init__(
             type=type,
+            name=name,
             description=STORY_WEAVER_PROMPT,
             short_description=STORY_WEAVER_SHORT_DESCRIPTION,
         ) 


### PR DESCRIPTION
- type should represent the subclass of BaseAgent and used for classification.
- an agent can have a name now which will be the primary identifier.
- updated all examples.
- name is optional for backward compatibility.