### PR TITLE
Add PydanticAI integration

### DIFF
--- a/integration_tests/test_pydantic.py
+++ b/integration_tests/test_pydantic.py
@@ -1,0 +1,107 @@
+"""Small but complete example of using PydanticAI to build a support agent for a bank.
+
+Run with:
+
+    uv run -m pydantic_ai_examples.bank_support
+"""
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field
+
+from pydantic_ai import Agent, RunContext
+
+from mahilo.agent import BaseAgent
+from mahilo.agent_manager import AgentManager
+from mahilo.integrations.pydanticai.agent import PydanticAIAgent
+from mahilo.server import ServerManager
+
+
+class DatabaseConn:
+    """This is a fake database for example purposes.
+
+    In reality, you'd be connecting to an external database
+    (e.g. PostgreSQL) to get information about customers.
+    """
+
+    @classmethod
+    async def customer_name(cls, *, id: int) -> str | None:
+        if id == 123:
+            return 'John'
+
+    @classmethod
+    async def customer_balance(cls, *, id: int, include_pending: bool) -> float:
+        if id == 123:
+            return 123.45
+        else:
+            raise ValueError('Customer not found')
+
+
+@dataclass
+class SupportDependencies:
+    customer_id: int
+    db: DatabaseConn
+
+
+class SupportResult(BaseModel):
+    support_advice: str = Field(description='Advice returned to the customer')
+    block_card: bool = Field(description='Whether to block their')
+    risk: int = Field(description='Risk level of query', ge=0, le=10)
+
+
+support_agent = Agent(
+    'openai:gpt-4o',
+    deps_type=SupportDependencies,
+    result_type=SupportResult,
+    system_prompt=(
+        'You are a support agent in our bank, give the '
+        'customer support and judge the risk level of their query. '
+        "Reply using the customer's name."
+    ),
+)
+
+
+@support_agent.system_prompt
+async def add_customer_name(ctx: RunContext[SupportDependencies]) -> str:
+    customer_name = await ctx.deps.db.customer_name(id=ctx.deps.customer_id)
+    return f"The customer's name is {customer_name!r}"
+
+
+@support_agent.tool
+async def customer_balance(
+    ctx: RunContext[SupportDependencies], include_pending: bool
+) -> str:
+    """Returns the customer's current account balance."""
+    balance = await ctx.deps.db.customer_balance(
+        id=ctx.deps.customer_id,
+        include_pending=include_pending,
+    )
+    return f'${balance:.2f}'
+
+mahilo_pydantic_agent = PydanticAIAgent(
+    pydantic_agent=support_agent,
+    name="SupportAgent",
+    description="You can talk to other agents as needed too to answer user questions. When you do so, let the user know that you are talking to another agent.",
+    can_contact=[],
+    short_description="",
+)
+
+mahilo_base_agent = BaseAgent(
+    name="WeatherAgent",
+    type="weather_agent",
+    description="When someone asks you about the weather, ask your human for it.",
+    can_contact=[],
+    short_description="",
+)
+
+manager = AgentManager()
+manager.register_agent(mahilo_pydantic_agent)
+manager.register_agent(mahilo_base_agent)
+
+mahilo_pydantic_agent.activate(dependencies=SupportDependencies(customer_id=123, db=DatabaseConn()))
+
+server = ServerManager(manager)
+
+
+if __name__ == '__main__':
+    server.run()

--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -701,7 +701,7 @@ class BaseAgent:
         # if session is not None, then the agent is active
         return self._session is not None
     
-    def activate(self, server_id: str = None) -> None:
+    def activate(self, server_id: str = None, dependencies: Any = None) -> None:
         """Activate the agent."""
         self._session = Session(self.TYPE, server_id)
 

--- a/mahilo/integrations/langgraph/agent.py
+++ b/mahilo/integrations/langgraph/agent.py
@@ -91,7 +91,7 @@ class LanggraphMahiloAgent(BaseAgent):
         ]
 
         print("Activated agents:", activated_agents)
-        print("In process_chat_message:", response_text)
+        print(f"In process_chat_message: Response for {self.name}: {response_text}")
 
         return {
             "response": response_text,
@@ -128,4 +128,4 @@ class LanggraphMahiloAgent(BaseAgent):
         for ws in websockets:
             await ws.send_text(response_text)
 
-        print("In queue fn:", response_text)
+        print(f"In process_queue_message: Response for {self.name}: {response_text}")

--- a/mahilo/integrations/pydanticai/agent.py
+++ b/mahilo/integrations/pydanticai/agent.py
@@ -1,0 +1,127 @@
+from typing import Any, Dict, List, Optional
+from fastapi import WebSocket
+from mahilo.agent import BaseAgent
+from pydantic_ai import Agent, RunContext
+from rich.console import Console
+
+from mahilo.integrations.pydanticai.tools import get_chat_with_agent_tool_pydanticai
+
+console = Console()
+
+class PydanticAIAgent(BaseAgent):
+    """Adapter class to use PydanticAI agents within the mahilo framework."""
+    
+    def __init__(self, 
+                 pydantic_agent: Agent,  # The actual PydanticAI agent instance
+                 type: str = "pydantic_ai",
+                 name: str = None,
+                 description: str = None,
+                 can_contact: List[str] = [],
+                 short_description: str = None):
+        """Initialize a PydanticAIAgent.
+        
+        Args:
+            pydantic_agent: The PydanticAI agent instance to wrap
+            type: The type of agent
+            name: Unique name for this agent instance
+            description: Long description of the agent
+            can_contact: List of agent types this agent can contact
+            short_description: Brief description of the agent
+        """
+        super().__init__(
+            type=type,
+            name=name,
+            description=description,
+            can_contact=can_contact,
+            short_description=short_description
+        )
+        self._pydantic_agent = pydantic_agent
+        self._dependencies = None
+        self._add_mahilo_tools()
+        self.add_system_prompt()
+        self._instructions = """
+            If you have asked another agent a question already, do not ask it again.
+            Wait until they reach out to you actively. Meanwhile, you can just wait and
+            let the user know that you are waiting for the other agent to respond.
+            """
+
+    def _add_mahilo_tools(self):
+        """Add the mahilo tools to the PydanticAI agent."""
+        _ = get_chat_with_agent_tool_pydanticai(self._pydantic_agent)
+
+    def activate(self, server_id: str = None, dependencies: Any = None) -> None:
+        """Activate the PydanticAI agent."""
+        super().activate(server_id, dependencies)
+        self._dependencies = dependencies
+
+    def add_system_prompt(self) -> None:
+        """Add a system prompt to the PydanticAI agent."""
+        @self._pydantic_agent.system_prompt
+        def system_prompt_func(ctx: RunContext[Any]) -> str:
+            return self.description + "\n" + self._instructions
+        
+    async def process_chat_message(self, message: str = None, websockets: List[WebSocket] = []) -> Dict[str, Any]:
+        """Process a message using the PydanticAI agent's run method."""
+        if not message:
+            return {"response": "", "activated_agents": []}
+
+        # Get context from other agents
+        other_agent_messages = self._agent_manager.get_agent_messages(self.name, num_messages=7)
+        
+        message_full = f"{other_agent_messages}"
+        available_agents = self.get_contactable_agents_with_description()
+        if message:
+            message_full += f"\nUser: {message}"
+            console.print("[bold blue]🤖 Available Agents:[/bold blue]")
+            for agent_type, desc in available_agents.items():
+                console.print(f"  [green]▪[/green] [cyan]{agent_type}:[/cyan] [dim]{desc}[/dim]")
+            message_full += f"\n Available agents to chat with: {available_agents}"
+            message_full += f"\n Your Agent Name: {self.name}"
+        
+        print("System prompts:", self._pydantic_agent._system_prompts)
+        print("Function tools:", self._pydantic_agent._function_tools)
+        # Run the PydanticAI agent
+        result = await self._pydantic_agent.run(message_full, deps=self._dependencies)
+        
+        # Convert the Pydantic model result to a string response
+        response_text = str(result.data)
+
+        # Get activated agents
+        activated_agents = [
+            agent.name for agent in self._agent_manager.get_all_agents() 
+            if agent.is_active() and agent.name != self.name
+        ]
+
+        print("Activated agents:", activated_agents)
+        print(f"In process_chat_message: Response for {self.name}: {response_text}")
+
+        return {
+            "response": response_text,
+            "activated_agents": activated_agents
+        }
+
+    async def process_queue_message(self, message: str = None, websockets: List[WebSocket] = []) -> None:
+        """Process a queue message using the PydanticAI agent."""
+        if not message:
+            return
+
+        message_full = f"Message from: {message}"
+        print(f"Queue message for {self.name}: {message_full}")
+        
+        available_agents = self.get_contactable_agents_with_description()
+        if message:
+            message_full += f"\n Available agents to chat with: {available_agents}"
+            console.print("[bold blue]🤖 Available Agents:[/bold blue]")
+            for agent_type, desc in available_agents.items():
+                console.print(f"  [green]▪[/green] [cyan]{agent_type}:[/cyan] [dim]{desc}[/dim]")
+            message_full += f"\n Your Agent Name: {self.name}"
+        
+        # Run the PydanticAI agent
+        result = await self._pydantic_agent.run(message_full, deps=self._dependencies)
+        response_text = str(result.data)
+
+        # Send the response to the websockets
+        for ws in websockets:
+            await ws.send_text(response_text)
+
+        print(f"In process_queue_message: Response for {self.name}: {response_text}")

--- a/mahilo/integrations/pydanticai/tools.py
+++ b/mahilo/integrations/pydanticai/tools.py
@@ -1,0 +1,22 @@
+from typing import Any, Callable
+from pydantic_ai import Agent, RunContext
+
+from mahilo.tools import get_chat_with_agent_tool
+
+def get_chat_with_agent_tool_pydanticai(agent: Agent) -> Callable:
+    """Get the chat with agent tool for PydanticAI."""
+    return agent.tool(chat_with_agent_tool_pydanticai)
+
+def chat_with_agent_tool_pydanticai(ctx: RunContext[Any], agent_name: str, your_name: str, question: str) -> str:
+    """Chat with an agent by their name.
+    
+    This is a tool that can be used in a PydanticAI agent to chat with another agent.
+    
+    Args:
+        ctx: The context of the PydanticAI agent.
+        agent_name: The name of the agent to chat with.
+        your_name: The name of the PydanticAI agent.
+        question: The question/message to ask the agent.
+    """
+    tool = get_chat_with_agent_tool()
+    return tool(agent_name, your_name, question)


### PR DESCRIPTION
## PydanticAI 🤝 mahilo

You can now register your PydanticAI agents as mahilo agents to make use of the mahilo network of agents and get realtime communication capability over voice and text for your LangGraph agents.

This PR introduces a wrapper class `PydanticAIAgent` that takes in your PydanticAI `Agent` object and creates a mahilo agent with it. No configuration or manual steps required, it is as simple as instantiating the `PydanticAIAgent` object as follows:

```python
mahilo_pydantic_agent = PydanticAIAgent(
    pydantic_agent=support_agent,
    name="SupportAgent",
    description="You can talk to other agents as needed too to answer user questions. When you do so, let the user know that you are talking to another agent.",
    can_contact=[],
    short_description="",
)
```
You can now make it a part of your agent manager and connect to this agent in realtime using websockets.

### Dependencies
Dependencies are supported through the `agent.activate(dependencies=Any)`  function of the `BaseAgent` class and you can define and pass dependencies at runtime using it.