### PR TITLE
Create a message protocol and broker. Add telemetry 🦸

### DIFF
--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -760,29 +760,6 @@ class BaseAgent:
     def activate(self, server_id: str = None, dependencies: Any = None) -> None:
         """Activate the agent."""
         self._session = Session(self.TYPE, server_id)
-
-    def chat_with_agent(self, agent_name: str, question: str) -> str:
-        """Chat with the agent of the given name."""
-        agent = self._agent_manager.get_agent(agent_name)
-        if not agent:
-            return f"Error: Agent with name '{agent_name}' not found"
-        
-        # if agent is not active, activate it
-        if not agent.is_active():
-            agent.activate()
-
-        # Send message through broker instead of directly to queue
-        self._agent_manager.send_message_to_agent(
-            sender=self.name,
-            recipient=agent_name,
-            message=question,
-            message_type=MessageType.DIRECT
-        )
-
-        return (
-            f"I have sent the message '{question}' to the agent named {agent_name}. "
-            "You will hear back soon."
-        )
     
     async def contact_human(self, message: str, websockets: List[WebSocket] = []) -> str:
         # Prioritize voice connections if available

--- a/mahilo/agent.py
+++ b/mahilo/agent.py
@@ -47,7 +47,6 @@ class BaseAgent:
     TYPE: str = "Base"
     name: str = None
     _agent_manager: "AgentManager"
-    _queue: List[str]
     _session: Optional[Session] = None
     description: str = None
     short_description: str = None
@@ -72,7 +71,6 @@ class BaseAgent:
         """
         self.TYPE = type
         self.name = name or f"{type}_{id(self)}"  # Default to type_uniqueid if no name given
-        self._queue = []
         self.description = description
         self.can_contact = can_contact
         self.short_description = short_description

--- a/mahilo/agent_manager.py
+++ b/mahilo/agent_manager.py
@@ -1,15 +1,18 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 from .agent import BaseAgent
-from .registry import GlobalRegistry
+from .registry import GlobalRegistry, AgentRegistry
+from .message_protocol import MessageBroker, MessageEnvelope, MessageType
 
 
-class AgentManager:
+class AgentManager(AgentRegistry):
     """A class to manage agents of different types.
     
-    This class should also have functions that can register new AgentTypes and keep track of them.
+    This class implements the AgentRegistry protocol and provides additional functionality
+    for managing agents and their communication.
     """
-    def __init__(self):
+    def __init__(self, secret_key: str = None):
         self.agents: Dict[str, BaseAgent] = {}
+        self.message_broker = MessageBroker(secret_key=secret_key)
         # Register self with global registry
         GlobalRegistry.set_agent_registry(self)
 
@@ -20,8 +23,8 @@ class AgentManager:
         agent._agent_manager = self
         self.agents[agent.name] = agent
 
-    def get_agent(self, agent_name: str) -> BaseAgent:
-        """Return the agent of the given name."""
+    def get_agent(self, agent_name: str) -> Optional[BaseAgent]:
+        """Return the agent of the given name. Implements AgentRegistry protocol."""
         return self.agents.get(agent_name)
     
     def get_all_agent_types(self) -> List[str]:
@@ -46,10 +49,26 @@ class AgentManager:
         self.agents.clear()
 
     def get_agent_types_with_description(self) -> Dict[str, str]:
-        """Return a list of all registered agent types with their descriptions."""
+        """Return a list of all registered agent types with their descriptions.
+        Implements AgentRegistry protocol."""
         return {agent.name: agent.short_description for agent in self.agents.values()}
     
-    # get last 3 messages from all agents' sessions except the current agent.
+    def send_message_to_agent(self, sender: str, recipient: str, message: str,
+                            message_type: MessageType = MessageType.DIRECT) -> None:
+        """Send a message to an agent through the broker."""
+        if recipient not in self.agents:
+            raise ValueError(f"Agent {recipient} not found")
+            
+        envelope = MessageEnvelope.create(
+            sender=sender,
+            recipient=recipient,
+            payload=message,
+            message_type=message_type,
+            secret_key=self.message_broker.secret_key
+        )
+        
+        self.message_broker.send_message(envelope)
+    
     def get_agent_messages(self, agent_name: str, num_messages: int = 7) -> str:
         """Return messages from all agents' sessions except the current agent."""
         messages = []

--- a/mahilo/agent_manager.py
+++ b/mahilo/agent_manager.py
@@ -34,7 +34,7 @@ class AgentManager(AgentRegistry):
         self.agents[agent.name] = agent
         
         self.telemetry.record_event(
-            event_type=EventType.AGENT_ACTIVATED,
+            event_type=EventType.AGENT_REGISTERED,
             agent_id=agent.name,
             details={
                 "type": agent.TYPE,
@@ -62,7 +62,7 @@ class AgentManager(AgentRegistry):
         """Unregister the agent of the given name."""
         if agent_name in self.agents:
             self.telemetry.record_event(
-                event_type=EventType.AGENT_DEACTIVATED,
+                event_type=EventType.AGENT_UNREGISTERED,
                 agent_id=agent_name
             )
             del self.agents[agent_name]

--- a/mahilo/message_protocol.py
+++ b/mahilo/message_protocol.py
@@ -1,0 +1,107 @@
+import uuid
+import time
+import json
+import jwt
+from dataclasses import dataclass, asdict
+from typing import Dict, Any, Optional, List
+from enum import Enum
+
+class MessageType(Enum):
+    DIRECT = "direct"
+    BROADCAST = "broadcast"
+    RESPONSE = "response"
+    ERROR = "error"
+
+@dataclass
+class MessageEnvelope:
+    """Message envelope containing metadata and payload"""
+    message_id: str
+    sender: str
+    recipient: str
+    message_type: MessageType
+    payload: str
+    timestamp: float
+    correlation_id: Optional[str] = None
+    reply_to: Optional[str] = None
+    signature: Optional[str] = None
+    
+    @classmethod
+    def create(cls, sender: str, recipient: str, payload: str, 
+               message_type: MessageType = MessageType.DIRECT,
+               correlation_id: Optional[str] = None,
+               reply_to: Optional[str] = None,
+               secret_key: Optional[str] = None) -> 'MessageEnvelope':
+        """Create a new message envelope"""
+        msg = cls(
+            message_id=str(uuid.uuid4()),
+            sender=sender,
+            recipient=recipient,
+            message_type=message_type,
+            payload=payload,
+            timestamp=time.time(),
+            correlation_id=correlation_id,
+            reply_to=reply_to
+        )
+        
+        if secret_key:
+            # Sign the message if secret key is provided
+            msg.signature = jwt.encode(
+                {"message_id": msg.message_id, "payload": msg.payload},
+                secret_key,
+                algorithm="HS256"
+            )
+        
+        return msg
+    
+    def verify(self, secret_key: str) -> bool:
+        """Verify message signature"""
+        if not self.signature:
+            return False
+        try:
+            decoded = jwt.decode(self.signature, secret_key, algorithms=["HS256"])
+            return (decoded["message_id"] == self.message_id and 
+                   decoded["payload"] == self.payload)
+        except jwt.InvalidTokenError:
+            return False
+            
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary"""
+        return {
+            k: str(v) if isinstance(v, MessageType) else v 
+            for k, v in asdict(self).items()
+        }
+
+class MessageBroker:
+    """Message broker for handling inter-agent communication"""
+    def __init__(self, secret_key: Optional[str] = None):
+        self.secret_key = secret_key
+        self.pending_messages: Dict[str, List[MessageEnvelope]] = {}
+        self.retry_counts: Dict[str, int] = {}
+        self.MAX_RETRIES = 3
+        
+    def send_message(self, message: MessageEnvelope) -> None:
+        """Queue a message for delivery"""
+        if message.recipient not in self.pending_messages:
+            self.pending_messages[message.recipient] = []
+        self.pending_messages[message.recipient].append(message)
+        
+    def get_pending_messages(self, recipient: str) -> List[MessageEnvelope]:
+        """Get pending messages for a recipient"""
+        return self.pending_messages.get(recipient, [])
+        
+    def acknowledge_message(self, message_id: str, recipient: str) -> None:
+        """Acknowledge successful message processing"""
+        if recipient in self.pending_messages:
+            self.pending_messages[recipient] = [
+                msg for msg in self.pending_messages[recipient] 
+                if msg.message_id != message_id
+            ]
+            if message_id in self.retry_counts:
+                del self.retry_counts[message_id]
+                
+    def handle_failure(self, message_id: str, recipient: str) -> bool:
+        """Handle message processing failure
+        Returns True if should retry, False if max retries exceeded
+        """
+        self.retry_counts[message_id] = self.retry_counts.get(message_id, 0) + 1
+        return self.retry_counts[message_id] <= self.MAX_RETRIES 

--- a/mahilo/message_protocol.py
+++ b/mahilo/message_protocol.py
@@ -3,10 +3,12 @@ import time
 import json
 import jwt
 from dataclasses import dataclass, asdict
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from enum import Enum
 
-from mahilo.monitoring import EventType
+if TYPE_CHECKING:
+    from mahilo.message_store import MessageStore
+from mahilo.monitoring import EventType, MahiloTelemetry
 
 class MessageType(Enum):
     DIRECT = "direct"
@@ -75,7 +77,7 @@ class MessageEnvelope:
 
 class MessageBroker:
     """Message broker for handling inter-agent communication"""
-    def __init__(self, secret_key: Optional[str] = None, store = None, telemetry = None):
+    def __init__(self, secret_key: Optional[str] = None, store: Optional["MessageStore"] = None, telemetry: Optional["MahiloTelemetry"] = None):
         self.secret_key = secret_key
         self.store = store
         self.telemetry = telemetry

--- a/mahilo/message_protocol.py
+++ b/mahilo/message_protocol.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, asdict
 from typing import Dict, Any, Optional, List
 from enum import Enum
 
+from mahilo.monitoring import EventType
+
 class MessageType(Enum):
     DIRECT = "direct"
     BROADCAST = "broadcast"
@@ -73,35 +75,105 @@ class MessageEnvelope:
 
 class MessageBroker:
     """Message broker for handling inter-agent communication"""
-    def __init__(self, secret_key: Optional[str] = None):
+    def __init__(self, secret_key: Optional[str] = None, store = None, monitor = None):
         self.secret_key = secret_key
-        self.pending_messages: Dict[str, List[MessageEnvelope]] = {}
-        self.retry_counts: Dict[str, int] = {}
+        self.store = store
+        self.monitor = monitor
         self.MAX_RETRIES = 3
         
     def send_message(self, message: MessageEnvelope) -> None:
         """Queue a message for delivery"""
-        if message.recipient not in self.pending_messages:
-            self.pending_messages[message.recipient] = []
-        self.pending_messages[message.recipient].append(message)
+        if self.store:
+            self.store.save_message(message)
+            
+        if self.monitor:
+            self.monitor.record_event(
+                event_type=EventType.MESSAGE_SENT,
+                correlation_id=message.correlation_id,
+                agent_id=message.sender,
+                message_id=message.message_id,
+                details={
+                    "recipient": message.recipient,
+                    "message_type": message.message_type.value
+                }
+            )
         
     def get_pending_messages(self, recipient: str) -> List[MessageEnvelope]:
         """Get pending messages for a recipient"""
-        return self.pending_messages.get(recipient, [])
+        messages = []
+        if self.store:
+            messages = self.store.get_pending_messages(recipient)
+            
+        if self.monitor and messages:
+            self.monitor.record_event(
+                event_type=EventType.QUEUE_LENGTH_CHANGED,
+                agent_id=recipient,
+                details={"queue_length": len(messages)}
+            )
+            
+        return messages
         
     def acknowledge_message(self, message_id: str, recipient: str) -> None:
         """Acknowledge successful message processing"""
-        if recipient in self.pending_messages:
-            self.pending_messages[recipient] = [
-                msg for msg in self.pending_messages[recipient] 
-                if msg.message_id != message_id
-            ]
-            if message_id in self.retry_counts:
-                del self.retry_counts[message_id]
+        if self.store:
+            message = self.store.get_message(message_id)
+            if message:
+                self.store.update_message_state(message_id, "processed")
+                
+                if self.monitor:
+                    self.monitor.record_event(
+                        event_type=EventType.MESSAGE_PROCESSED,
+                        correlation_id=message.correlation_id,
+                        agent_id=recipient,
+                        message_id=message_id,
+                        details={
+                            "sender": message.sender,
+                            "message_type": message.message_type.value
+                        }
+                    )
                 
     def handle_failure(self, message_id: str, recipient: str) -> bool:
         """Handle message processing failure
         Returns True if should retry, False if max retries exceeded
         """
-        self.retry_counts[message_id] = self.retry_counts.get(message_id, 0) + 1
-        return self.retry_counts[message_id] <= self.MAX_RETRIES 
+        if not self.store:
+            return False
+            
+        message = self.store.get_message(message_id)
+        if not message:
+            return False
+            
+        retry_count = self.store.get_retry_count(message_id) + 1
+            
+        if retry_count <= self.MAX_RETRIES:
+            self.store.update_message_state(message_id, "pending", retry_count)
+            
+            if self.monitor:
+                self.monitor.record_event(
+                    event_type=EventType.RETRY,
+                    correlation_id=message.correlation_id,
+                    agent_id=recipient,
+                    message_id=message_id,
+                    details={
+                        "retry_count": retry_count,
+                        "max_retries": self.MAX_RETRIES
+                    }
+                )
+            return True
+            
+        self.store.update_message_state(message_id, "failed", retry_count)
+        
+        if self.monitor:
+            self.monitor.record_event(
+                event_type=EventType.MESSAGE_FAILED,
+                correlation_id=message.correlation_id,
+                agent_id=recipient,
+                message_id=message_id,
+                details={
+                    "retry_count": retry_count,
+                    "max_retries": self.MAX_RETRIES,
+                    "sender": message.sender,
+                    "message_type": message.message_type.value
+                }
+            )
+        return False 

--- a/mahilo/message_store.py
+++ b/mahilo/message_store.py
@@ -1,0 +1,192 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+import sqlite3
+import json
+from datetime import datetime, timedelta
+from .message_protocol import MessageEnvelope, MessageType
+
+class MessageState:
+    PENDING = "pending"
+    PROCESSED = "processed" 
+    FAILED = "failed"
+
+class MessageStore(ABC):
+    """Protocol defining message persistence operations"""
+    
+    @abstractmethod
+    def save_message(self, message: MessageEnvelope, state: str = MessageState.PENDING) -> None:
+        """Save a message to persistent storage"""
+        pass
+    
+    @abstractmethod
+    def get_message(self, message_id: str) -> Optional[MessageEnvelope]:
+        """Retrieve a message by ID"""
+        pass
+    
+    @abstractmethod
+    def get_pending_messages(self, recipient: str) -> List[MessageEnvelope]:
+        """Get all pending messages for a recipient"""
+        pass
+    
+    @abstractmethod
+    def get_message_history(self, agent_id: str, 
+                          start_time: Optional[datetime] = None,
+                          end_time: Optional[datetime] = None) -> List[MessageEnvelope]:
+        """Get message history for an agent"""
+        pass
+    
+    @abstractmethod
+    def update_message_state(self, message_id: str, state: str, 
+                           retry_count: Optional[int] = None) -> None:
+        """Update message state and retry information"""
+        pass
+    
+    @abstractmethod
+    def cleanup_old_messages(self, max_age_days: int = 30) -> None:
+        """Remove processed messages older than specified age"""
+        pass
+
+    @abstractmethod
+    def get_retry_count(self, message_id: str) -> int:
+        """Get the current retry count for a message"""
+        pass
+
+class SQLiteMessageStore(MessageStore):
+    """SQLite implementation of MessageStore"""
+    
+    def __init__(self, db_path: str = "messages.db"):
+        self.db_path = db_path
+        self._init_db()
+    
+    def _init_db(self):
+        """Initialize database schema"""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS messages (
+                    message_id TEXT PRIMARY KEY,
+                    sender TEXT NOT NULL,
+                    recipient TEXT NOT NULL,
+                    message_type TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    timestamp REAL NOT NULL,
+                    correlation_id TEXT,
+                    reply_to TEXT,
+                    signature TEXT,
+                    state TEXT NOT NULL,
+                    retry_count INTEGER DEFAULT 0,
+                    last_retry REAL,
+                    created_at REAL NOT NULL
+                )
+            """)
+            # Create indexes
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_message_id ON messages(message_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_sender ON messages(sender)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_recipient ON messages(recipient)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_timestamp ON messages(timestamp)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_state ON messages(state)")
+    
+    def save_message(self, message: MessageEnvelope, state: str = MessageState.PENDING) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                INSERT INTO messages (
+                    message_id, sender, recipient, message_type, payload,
+                    timestamp, correlation_id, reply_to, signature,
+                    state, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                message.message_id, message.sender, message.recipient,
+                message.message_type.value, message.payload, message.timestamp,
+                message.correlation_id, message.reply_to, message.signature,
+                state, datetime.now().timestamp()
+            ))
+    
+    def get_message(self, message_id: str) -> Optional[MessageEnvelope]:
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM messages WHERE message_id = ?", 
+                (message_id,)
+            ).fetchone()
+            
+            if row:
+                return self._row_to_envelope(row)
+            return None
+    
+    def get_pending_messages(self, recipient: str) -> List[MessageEnvelope]:
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT * FROM messages WHERE recipient = ? AND state = ?",
+                (recipient, MessageState.PENDING)
+            ).fetchall()
+            return [self._row_to_envelope(row) for row in rows]
+    
+    def get_message_history(self, agent_id: str, 
+                          start_time: Optional[datetime] = None,
+                          end_time: Optional[datetime] = None) -> List[MessageEnvelope]:
+        query = """
+            SELECT * FROM messages 
+            WHERE (sender = ? OR recipient = ?)
+        """
+        params = [agent_id, agent_id]
+        
+        if start_time:
+            query += " AND timestamp >= ?"
+            params.append(start_time.timestamp())
+        if end_time:
+            query += " AND timestamp <= ?"
+            params.append(end_time.timestamp())
+            
+        query += " ORDER BY timestamp DESC"
+        
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(query, params).fetchall()
+            return [self._row_to_envelope(row) for row in rows]
+    
+    def update_message_state(self, message_id: str, state: str, 
+                           retry_count: Optional[int] = None) -> None:
+        query = """
+            UPDATE messages 
+            SET state = ?,
+                last_retry = ?
+        """
+        params = [state, datetime.now().timestamp()]
+        
+        if retry_count is not None:
+            query += ", retry_count = ?"
+            params.append(retry_count)
+            
+        query += " WHERE message_id = ?"
+        params.append(message_id)
+        
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(query, params)
+    
+    def cleanup_old_messages(self, max_age_days: int = 30) -> None:
+        cutoff = datetime.now() - timedelta(days=max_age_days)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "DELETE FROM messages WHERE state = ? AND timestamp < ?",
+                (MessageState.PROCESSED, cutoff.timestamp())
+            )
+    
+    def get_retry_count(self, message_id: str) -> int:
+        """Get the current retry count for a message"""
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT retry_count FROM messages WHERE message_id = ?",
+                (message_id,)
+            ).fetchone()
+            return row[0] if row else 0
+    
+    def _row_to_envelope(self, row) -> MessageEnvelope:
+        """Convert a database row to MessageEnvelope"""
+        return MessageEnvelope(
+            message_id=row[0],
+            sender=row[1],
+            recipient=row[2],
+            message_type=MessageType(row[3]),
+            payload=row[4],
+            timestamp=row[5],
+            correlation_id=row[6],
+            reply_to=row[7],
+            signature=row[8]
+        ) 

--- a/mahilo/monitoring.py
+++ b/mahilo/monitoring.py
@@ -23,6 +23,8 @@ class EventType(Enum):
     # Agent events
     AGENT_ACTIVATED = "agent_activated"
     AGENT_DEACTIVATED = "agent_deactivated"
+    AGENT_REGISTERED = "agent_registered"
+    AGENT_UNREGISTERED = "agent_unregistered"
     
     # Processing events
     PROCESSING_STARTED = "processing_started"

--- a/mahilo/monitoring.py
+++ b/mahilo/monitoring.py
@@ -112,9 +112,9 @@ class MahiloTelemetry:
     
     def record_event(self, 
                     event_type: EventType,
-                    correlation_id: Optional[str] = "",
-                    agent_id: Optional[str] = "",
-                    message_id: Optional[str] = "",
+                    correlation_id: Optional[str] = None,
+                    agent_id: Optional[str] = None,
+                    message_id: Optional[str] = None,
                     details: Dict = {}):
         """Record a monitoring event using OpenTelemetry"""
         attributes = {

--- a/mahilo/monitoring.py
+++ b/mahilo/monitoring.py
@@ -1,0 +1,166 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Optional
+import logging
+import json
+from enum import Enum
+import time
+import threading
+from collections import defaultdict
+
+class EventType(Enum):
+    # Message events
+    MESSAGE_SENT = "message_sent"
+    MESSAGE_RECEIVED = "message_received"
+    MESSAGE_PROCESSED = "message_processed"
+    MESSAGE_FAILED = "message_failed"
+    
+    # Agent events
+    AGENT_ACTIVATED = "agent_activated"
+    AGENT_DEACTIVATED = "agent_deactivated"
+    
+    # Processing events
+    PROCESSING_STARTED = "processing_started"
+    PROCESSING_COMPLETED = "processing_completed"
+    
+    # System events
+    ERROR = "error"
+    RETRY = "retry"
+    QUEUE_LENGTH_CHANGED = "queue_length_changed"
+    CONNECTION_EVENT = "connection_event"
+
+@dataclass
+class MonitoringEvent:
+    event_type: EventType
+    timestamp: float
+    correlation_id: Optional[str]
+    agent_id: Optional[str]
+    message_id: Optional[str]
+    details: Dict
+    duration_ms: Optional[float] = None
+
+class MetricsCollector:
+    """Collects and aggregates monitoring metrics"""
+    
+    def __init__(self):
+        self.metrics = defaultdict(lambda: defaultdict(float))
+        self.event_counts = defaultdict(int)
+        self._lock = threading.Lock()
+        
+    def record_event(self, event: MonitoringEvent):
+        with self._lock:
+            # Update event counts
+            self.event_counts[event.event_type] += 1
+            
+            # Record agent-specific metrics
+            if event.agent_id:
+                agent_metrics = self.metrics[event.agent_id]
+                
+                if event.event_type == EventType.MESSAGE_PROCESSED:
+                    agent_metrics["messages_processed"] += 1
+                    if event.duration_ms:
+                        agent_metrics["total_processing_time_ms"] += event.duration_ms
+                        agent_metrics["avg_processing_time_ms"] = (
+                            agent_metrics["total_processing_time_ms"] / 
+                            agent_metrics["messages_processed"]
+                        )
+                
+                elif event.event_type == EventType.MESSAGE_FAILED:
+                    agent_metrics["messages_failed"] += 1
+                
+                elif event.event_type == EventType.RETRY:
+                    agent_metrics["retries"] += 1
+    
+    def get_metrics(self, agent_id: Optional[str] = None) -> Dict:
+        """Get current metrics, optionally filtered by agent"""
+        with self._lock:
+            if agent_id:
+                return dict(self.metrics[agent_id])
+            return {
+                "event_counts": dict(self.event_counts),
+                "agent_metrics": {
+                    agent: dict(metrics)
+                    for agent, metrics in self.metrics.items()
+                }
+            }
+
+class MessageMonitor:
+    """Central monitoring system for message and agent events"""
+    
+    def __init__(self, log_file: str = "mahilo_events.log"):
+        self.metrics = MetricsCollector()
+        
+        # Configure logging
+        self.logger = logging.getLogger("mahilo.monitoring")
+        self.logger.setLevel(logging.INFO)
+        
+        # File handler
+        fh = logging.FileHandler(log_file)
+        fh.setLevel(logging.INFO)
+        formatter = logging.Formatter(
+            '%(asctime)s - %(levelname)s - %(message)s'
+        )
+        fh.setFormatter(formatter)
+        self.logger.addHandler(fh)
+        
+        # Processing time tracking
+        self.processing_start_times: Dict[str, float] = {}
+    
+    def record_event(self, 
+                    event_type: EventType,
+                    correlation_id: Optional[str] = None,
+                    agent_id: Optional[str] = None,
+                    message_id: Optional[str] = None,
+                    details: Dict = None):
+        """Record a monitoring event"""
+        
+        timestamp = time.time()
+        duration_ms = None
+        
+        # Calculate duration for processing events
+        if event_type == EventType.PROCESSING_STARTED:
+            self.processing_start_times[message_id] = timestamp
+        elif event_type == EventType.PROCESSING_COMPLETED:
+            start_time = self.processing_start_times.get(message_id)
+            if start_time:
+                duration_ms = (timestamp - start_time) * 1000
+                del self.processing_start_times[message_id]
+        
+        event = MonitoringEvent(
+            event_type=event_type,
+            timestamp=timestamp,
+            correlation_id=correlation_id,
+            agent_id=agent_id,
+            message_id=message_id,
+            details=details or {},
+            duration_ms=duration_ms
+        )
+        
+        # Update metrics
+        self.metrics.record_event(event)
+        
+        # Log the event
+        log_data = {
+            "event_type": event_type.value,
+            "timestamp": datetime.fromtimestamp(timestamp).isoformat(),
+            "correlation_id": correlation_id,
+            "agent_id": agent_id,
+            "message_id": message_id,
+            "duration_ms": duration_ms,
+            **details
+        }
+        self.logger.info(json.dumps(log_data))
+    
+    def get_metrics(self, agent_id: Optional[str] = None) -> Dict:
+        """Get current metrics"""
+        return self.metrics.get_metrics(agent_id)
+    
+    def get_agent_performance(self, agent_id: str) -> Dict:
+        """Get detailed performance metrics for an agent"""
+        metrics = self.metrics.get_metrics(agent_id)
+        return {
+            "messages_processed": metrics.get("messages_processed", 0),
+            "messages_failed": metrics.get("messages_failed", 0),
+            "avg_processing_time_ms": metrics.get("avg_processing_time_ms", 0),
+            "retries": metrics.get("retries", 0)
+        } 

--- a/mahilo/monitoring.py
+++ b/mahilo/monitoring.py
@@ -5,9 +5,13 @@ import logging
 import json
 from enum import Enum
 import time
-import threading
-from collections import defaultdict
-import sqlite3
+from opentelemetry import trace, metrics
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.metrics import Counter, UpDownCounter, Histogram
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.semconv.resource import ResourceAttributes
 
 class EventType(Enum):
     # Message events
@@ -40,184 +44,69 @@ class MonitoringEvent:
     details: Dict
     duration_ms: Optional[float] = None
 
-class MetricsStore:
-    """Persistent storage for monitoring metrics"""
+class MahiloTelemetry:
+    """OpenTelemetry-based monitoring for Mahilo"""
     
-    def __init__(self, db_path: str = "metrics.db"):
-        self.db_path = db_path
-        self._init_db()
+    def __init__(self, service_name: str = "mahilo"):
+        # Set up resource
+        resource = Resource.create({
+            ResourceAttributes.SERVICE_NAME: service_name
+        })
         
-    def _init_db(self):
-        with sqlite3.connect(self.db_path) as conn:
-            # Events table for raw event data
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS events (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    event_type TEXT NOT NULL,
-                    timestamp REAL NOT NULL,
-                    correlation_id TEXT,
-                    agent_id TEXT,
-                    message_id TEXT,
-                    details TEXT,
-                    duration_ms REAL
-                )
-            """)
-            
-            # Aggregated metrics table
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS agent_metrics (
-                    agent_id TEXT NOT NULL,
-                    metric_name TEXT NOT NULL,
-                    metric_value REAL NOT NULL,
-                    updated_at REAL NOT NULL,
-                    PRIMARY KEY (agent_id, metric_name)
-                )
-            """)
-            
-            # Create indexes
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_event_type ON events(event_type)")
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_agent_id ON events(agent_id)")
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_timestamp ON events(timestamp)")
-    
-    def record_event(self, event: MonitoringEvent):
-        """Record a monitoring event"""
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute("""
-                INSERT INTO events (
-                    event_type, timestamp, correlation_id, agent_id,
-                    message_id, details, duration_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """, (
-                event.event_type.value,
-                event.timestamp,
-                event.correlation_id,
-                event.agent_id,
-                event.message_id,
-                json.dumps(event.details),
-                event.duration_ms
-            ))
-            
-            # Update aggregated metrics
-            if event.agent_id:
-                self._update_agent_metrics(conn, event)
-    
-    def _update_agent_metrics(self, conn: sqlite3.Connection, event: MonitoringEvent):
-        """Update aggregated metrics for an agent"""
-        timestamp = time.time()
+        # Set up tracing
+        trace.set_tracer_provider(TracerProvider(resource=resource))
+        self.tracer = trace.get_tracer(__name__)
         
-        if event.event_type == EventType.MESSAGE_PROCESSED:
-            self._increment_metric(conn, event.agent_id, "messages_processed", 1, timestamp)
-            if event.duration_ms:
-                # Update average processing time
-                current_avg = self._get_metric(conn, event.agent_id, "avg_processing_time_ms")
-                current_count = self._get_metric(conn, event.agent_id, "messages_processed")
-                if current_count > 0:
-                    new_avg = ((current_avg * (current_count - 1)) + event.duration_ms) / current_count
-                    self._set_metric(conn, event.agent_id, "avg_processing_time_ms", new_avg, timestamp)
+        # Set up metrics
+        metrics.set_meter_provider(MeterProvider(resource=resource))
+        self.meter = metrics.get_meter(__name__)
         
-        elif event.event_type == EventType.MESSAGE_FAILED:
-            self._increment_metric(conn, event.agent_id, "messages_failed", 1, timestamp)
-        
-        elif event.event_type == EventType.RETRY:
-            self._increment_metric(conn, event.agent_id, "retries", 1, timestamp)
-    
-    def _increment_metric(self, conn: sqlite3.Connection, agent_id: str, 
-                         metric_name: str, increment: float, timestamp: float):
-        """Increment a metric value"""
-        conn.execute("""
-            INSERT INTO agent_metrics (agent_id, metric_name, metric_value, updated_at)
-            VALUES (?, ?, ?, ?)
-            ON CONFLICT(agent_id, metric_name) DO UPDATE SET
-                metric_value = metric_value + ?,
-                updated_at = ?
-        """, (agent_id, metric_name, increment, timestamp, increment, timestamp))
-    
-    def _set_metric(self, conn: sqlite3.Connection, agent_id: str, 
-                    metric_name: str, value: float, timestamp: float):
-        """Set a metric value"""
-        conn.execute("""
-            INSERT INTO agent_metrics (agent_id, metric_name, metric_value, updated_at)
-            VALUES (?, ?, ?, ?)
-            ON CONFLICT(agent_id, metric_name) DO UPDATE SET
-                metric_value = ?,
-                updated_at = ?
-        """, (agent_id, metric_name, value, timestamp, value, timestamp))
-    
-    def _get_metric(self, conn: sqlite3.Connection, agent_id: str, metric_name: str) -> float:
-        """Get current value of a metric"""
-        row = conn.execute("""
-            SELECT metric_value FROM agent_metrics
-            WHERE agent_id = ? AND metric_name = ?
-        """, (agent_id, metric_name)).fetchone()
-        return row[0] if row else 0
-    
-    def get_agent_metrics(self, agent_id: Optional[str] = None) -> Dict:
-        """Get metrics for an agent or all agents"""
-        with sqlite3.connect(self.db_path) as conn:
-            if agent_id:
-                rows = conn.execute("""
-                    SELECT metric_name, metric_value
-                    FROM agent_metrics
-                    WHERE agent_id = ?
-                """, (agent_id,)).fetchall()
-                return {row[0]: row[1] for row in rows}
-            
-            # Get all agent metrics
-            rows = conn.execute("""
-                SELECT agent_id, metric_name, metric_value
-                FROM agent_metrics
-            """).fetchall()
-            
-            metrics = defaultdict(dict)
-            for row in rows:
-                metrics[row[0]][row[1]] = row[2]
-            return dict(metrics)
-    
-    def cleanup_old_events(self, max_age_days: int = 30):
-        """Clean up old events while preserving aggregated metrics"""
-        cutoff = time.time() - (max_age_days * 24 * 60 * 60)
-        with sqlite3.connect(self.db_path) as conn:
-            conn.execute("DELETE FROM events WHERE timestamp < ?", (cutoff,))
-
-class MetricsCollector:
-    """Collects and aggregates monitoring metrics"""
-    
-    def __init__(self, store: Optional[MetricsStore] = None):
-        self.store = store
-        self._lock = threading.Lock()
-        
-    def record_event(self, event: MonitoringEvent):
-        with self._lock:
-            if self.store:
-                self.store.record_event(event)
-    
-    def get_metrics(self, agent_id: Optional[str] = None) -> Dict:
-        """Get current metrics, optionally filtered by agent"""
-        if self.store:
-            return self.store.get_agent_metrics(agent_id)
-        return {}
-
-class MessageMonitor:
-    """Central monitoring system for message and agent events"""
-    
-    def __init__(self, metrics_db: str = "metrics.db", log_file: str = "mahilo_events.log"):
-        self.metrics = MetricsCollector(MetricsStore(metrics_db))
+        # Create metrics
+        self._setup_metrics()
         
         # Configure logging
         self.logger = logging.getLogger("mahilo.monitoring")
-        self.logger.setLevel(logging.INFO)
         
-        # File handler
-        fh = logging.FileHandler(log_file)
-        fh.setLevel(logging.INFO)
-        formatter = logging.Formatter(
-            '%(asctime)s - %(levelname)s - %(message)s'
+    def _setup_metrics(self):
+        """Set up OpenTelemetry metrics"""
+        # Message metrics
+        self.message_counter = self.meter.create_counter(
+            "mahilo.messages",
+            description="Number of messages processed",
+            unit="1"
         )
-        fh.setFormatter(formatter)
-        self.logger.addHandler(fh)
         
-        # Processing time tracking
-        self.processing_start_times: Dict[str, float] = {}
+        self.message_processing_time = self.meter.create_histogram(
+            "mahilo.message.processing_time",
+            description="Time taken to process messages",
+            unit="ms"
+        )
+        
+        self.message_retry_counter = self.meter.create_counter(
+            "mahilo.message.retries",
+            description="Number of message retries",
+            unit="1"
+        )
+        
+        self.message_failure_counter = self.meter.create_counter(
+            "mahilo.message.failures",
+            description="Number of message failures",
+            unit="1"
+        )
+        
+        # Queue metrics
+        self.queue_size = self.meter.create_up_down_counter(
+            "mahilo.queue.size",
+            description="Current queue size",
+            unit="1"
+        )
+        
+        # Agent metrics
+        self.active_agents = self.meter.create_up_down_counter(
+            "mahilo.agents.active",
+            description="Number of active agents",
+            unit="1"
+        )
     
     def record_event(self, 
                     event_type: EventType,
@@ -225,55 +114,86 @@ class MessageMonitor:
                     agent_id: Optional[str] = None,
                     message_id: Optional[str] = None,
                     details: Dict = None):
-        """Record a monitoring event"""
-        
-        timestamp = time.time()
-        duration_ms = None
-        
-        # Calculate duration for processing events
-        if event_type == EventType.PROCESSING_STARTED:
-            self.processing_start_times[message_id] = timestamp
-        elif event_type == EventType.PROCESSING_COMPLETED:
-            start_time = self.processing_start_times.get(message_id)
-            if start_time:
-                duration_ms = (timestamp - start_time) * 1000
-                del self.processing_start_times[message_id]
-        
-        event = MonitoringEvent(
-            event_type=event_type,
-            timestamp=timestamp,
-            correlation_id=correlation_id,
-            agent_id=agent_id,
-            message_id=message_id,
-            details=details or {},
-            duration_ms=duration_ms
-        )
-        
-        # Update metrics
-        self.metrics.record_event(event)
-        
-        # Log the event
-        log_data = {
+        """Record a monitoring event using OpenTelemetry"""
+        details = details or {}
+        attributes = {
             "event_type": event_type.value,
-            "timestamp": datetime.fromtimestamp(timestamp).isoformat(),
-            "correlation_id": correlation_id,
             "agent_id": agent_id,
             "message_id": message_id,
-            "duration_ms": duration_ms,
-            **details
+            "correlation_id": correlation_id
         }
-        self.logger.info(json.dumps(log_data))
+        
+        # Start a span for the event
+        with self.tracer.start_as_current_span(
+            f"mahilo.event.{event_type.value}",
+            attributes=attributes
+        ) as span:
+            # Record metrics based on event type
+            if event_type == EventType.MESSAGE_PROCESSED:
+                self.message_counter.add(1, attributes)
+                if "duration_ms" in details:
+                    self.message_processing_time.record(
+                        details["duration_ms"],
+                        attributes
+                    )
+                span.set_status(Status(StatusCode.OK))
+                
+            elif event_type == EventType.MESSAGE_FAILED:
+                self.message_failure_counter.add(1, attributes)
+                span.set_status(Status(StatusCode.ERROR))
+                if "error" in details:
+                    span.record_exception(details["error"])
+                
+            elif event_type == EventType.RETRY:
+                self.message_retry_counter.add(1, attributes)
+                
+            elif event_type == EventType.QUEUE_LENGTH_CHANGED:
+                self.queue_size.add(
+                    details.get("queue_length", 0) - details.get("previous_length", 0),
+                    attributes
+                )
+                
+            elif event_type == EventType.AGENT_ACTIVATED:
+                self.active_agents.add(1, attributes)
+                
+            elif event_type == EventType.AGENT_DEACTIVATED:
+                self.active_agents.add(-1, attributes)
+            
+            # Add event details to span
+            for key, value in details.items():
+                span.set_attribute(key, str(value))
+            
+            # Log the event
+            self.logger.info(json.dumps({
+                "event_type": event_type.value,
+                "timestamp": datetime.fromtimestamp(time.time()).isoformat(),
+                "correlation_id": correlation_id,
+                "agent_id": agent_id,
+                "message_id": message_id,
+                **details
+            }))
     
-    def get_metrics(self, agent_id: Optional[str] = None) -> Dict:
-        """Get current metrics"""
-        return self.metrics.get_metrics(agent_id)
+    def start_processing_span(self, message_id: str, agent_id: str) -> trace.Span:
+        """Start a processing span for message handling"""
+        return self.tracer.start_span(
+            "mahilo.message.processing",
+            attributes={
+                "message_id": message_id,
+                "agent_id": agent_id
+            }
+        )
     
-    def get_agent_performance(self, agent_id: str) -> Dict:
-        """Get detailed performance metrics for an agent"""
-        metrics = self.metrics.get_metrics(agent_id)
-        return {
-            "messages_processed": metrics.get("messages_processed", 0),
-            "messages_failed": metrics.get("messages_failed", 0),
-            "avg_processing_time_ms": metrics.get("avg_processing_time_ms", 0),
-            "retries": metrics.get("retries", 0)
-        } 
+    def get_metrics(self) -> Dict:
+        """Get current metrics (Note: In OpenTelemetry, metrics are typically
+        collected by the backend, this is just for compatibility)"""
+        # This would typically be handled by your metrics backend
+        return {}
+
+    def mark_span_success(self, span: trace.Span) -> None:
+        """Mark a span as successful"""
+        span.set_status(Status(StatusCode.OK))
+
+    def mark_span_error(self, span: trace.Span, exception: Exception) -> None:
+        """Mark a span as failed with an error"""
+        span.set_status(Status(StatusCode.ERROR))
+        span.record_exception(exception)

--- a/mahilo/monitoring.py
+++ b/mahilo/monitoring.py
@@ -112,17 +112,16 @@ class MahiloTelemetry:
     
     def record_event(self, 
                     event_type: EventType,
-                    correlation_id: Optional[str] = None,
-                    agent_id: Optional[str] = None,
-                    message_id: Optional[str] = None,
-                    details: Dict = None):
+                    correlation_id: Optional[str] = "",
+                    agent_id: Optional[str] = "",
+                    message_id: Optional[str] = "",
+                    details: Dict = {}):
         """Record a monitoring event using OpenTelemetry"""
-        details = details or {}
         attributes = {
             "event_type": event_type.value,
-            "agent_id": agent_id,
-            "message_id": message_id,
-            "correlation_id": correlation_id
+            "agent_id": agent_id or "",
+            "message_id": message_id or "",
+            "correlation_id": correlation_id or ""
         }
         
         # Start a span for the event

--- a/mahilo/server.py
+++ b/mahilo/server.py
@@ -142,15 +142,17 @@ class ServerManager:
     async def _handle_inter_agent_communication(self):
         while True:
             for agent in self.agent_manager.get_all_agents():
-                if agent.is_active() and agent._queue:
-                    message = agent._queue.pop(0)
-                    websockets = []
-                    try:
-                        websockets = self.websocket_connections[agent.name].values()
-                    except KeyError:
-                        self.console.print(f"[bold yellow]⚠️  No WebSocket connections found for agent:[/bold yellow] [green]{agent.name}[/green]")
-                    list_websockets = [ws for ws in websockets]
-                    await agent.process_queue_message(message, websockets=list_websockets)
+                if agent.is_active():
+                    # Get pending messages from broker for this agent
+                    pending_messages = self.agent_manager.message_broker.get_pending_messages(agent.name)
+                    if pending_messages:
+                        websockets = []
+                        try:
+                            websockets = self.websocket_connections[agent.name].values()
+                        except KeyError:
+                            self.console.print(f"[bold yellow]⚠️  No WebSocket connections found for agent:[/bold yellow] [green]{agent.name}[/green]")
+                        list_websockets = [ws for ws in websockets]
+                        await agent.process_queue_message(websockets=list_websockets)
             await asyncio.sleep(1)
     
     def run(self, host: str = "0.0.0.0", port: int = 8000):

--- a/mahilo/server.py
+++ b/mahilo/server.py
@@ -150,7 +150,10 @@ class ServerManager:
                         try:
                             websockets = self.websocket_connections[agent.name].values()
                         except KeyError:
-                            self.console.print(f"[bold yellow]⚠️  No WebSocket connections found for agent:[/bold yellow] [green]{agent.name}[/green]")
+                            # no websockets means no one is listening to this agent. this is fine
+                            # but the contact human function will not work.
+                            # don't wanna log this because it's inside a continuous loop
+                            pass
                         list_websockets = [ws for ws in websockets]
                         await agent.process_queue_message(websockets=list_websockets)
             await asyncio.sleep(1)

--- a/mahilo/tools.py
+++ b/mahilo/tools.py
@@ -1,5 +1,6 @@
 from typing import Callable
 from .registry import GlobalRegistry
+from .message_protocol import MessageType
 
 def get_chat_with_agent_tool() -> Callable:
     """Get the chat_with_agent tool that can be bound to LLMs."""
@@ -18,11 +19,16 @@ def get_chat_with_agent_tool() -> Callable:
         if not agent.is_active():
             agent.activate()
             
-        # add the question to the agent's queue
-        agent.add_message_to_queue(question, your_name)
+        # Send message through broker instead of directly to queue
+        registry.send_message_to_agent(
+            sender=your_name,
+            recipient=agent_name,
+            message=question,
+            message_type=MessageType.DIRECT
+        )
         
         return (
-            f"I have put the question '{question}' in the queue for the agent named {agent_name}. "
+            f"I have sent the message '{question}' to the agent named {agent_name}. "
             "You will hear back soon."
         )
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,14 @@ rich==13.9.3
 langgraph==0.2.60
 pydantic-ai==0.0.15
 PyJWT==2.8.0
+
+# OpenTelemetry
+opentelemetry-api>=1.21.0
+opentelemetry-sdk>=1.21.0
+opentelemetry-instrumentation>=0.42b0
+opentelemetry-semantic-conventions>=0.42b0
+
+# Optional exporters (uncomment the ones you want to use)
+# opentelemetry-exporter-otlp>=1.21.0  # OTLP exporter
+# opentelemetry-exporter-prometheus>=1.21.0  # Prometheus exporter
+# opentelemetry-exporter-jaeger>=1.21.0  # Jaeger exporter

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ click==8.1.7
 rich==13.9.3
 langgraph==0.2.60
 pydantic-ai==0.0.15
+PyJWT==2.8.0


### PR DESCRIPTION
This PR does two things: introduces a message protocol and a message broker, and adds OpenTelemetry based instrumentation. With this, all inter-agent messages are tracked, secured through HS256 encryption, retried on failure and the sending agents are notified if their messages haven't gone through. In addition, all of this is tracked through traces and some useful metrics are also stored.

## Message Protocol
So far, inter-agent communication happened through simple text messages, which would be put in the queue for an agent, following which it would process it. This however, meant that these messages were not very well tracked as they moved through the system.

With the new message protocol, every message is represented as follows:
```json
{
  "message_id": "550e8400-e29b-41d4-a716-446655440000",
  "sender": "agent1",
  "recipient": "agent2",
  "message_type": "direct",
  "payload": "Hello, agent2!",
  "timestamp": 1710234567.89,
  "correlation_id": "123",
  "reply_to": "agent1",
  "signature": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
}
```
Many interesting things:
- every message independently tells you where it's coming from and where it should go.
- has a signature that is used to verify if the sender is legit
- correlation id, and message id used to track conversations

## Message Broker
Now, instead of the chat with agent function sending a message to the agent queue directly, all messages go through the message broker. 
The message broker has send message and acknowledge message functions which modify the state of the message object. 

The message broker has a store which stores the messages and a telemetry object that tracks all events.

## Message Store
A new interface that the message broker can use to store inter-agent messages. Right now, the only implementation is a SQLite store that maintains the messages and their state.

## OpenTelemetry Instrumentation
A new `MahiloTelemetry` class that uses a Traces and a Meter provider to generate metrics and traces for your mahilo system. The following metrics are supported:

```py
self.message_counter = self.meter.create_counter(
    "mahilo.messages",
    description="Number of messages processed",
    unit="1"
)

self.message_processing_time = self.meter.create_histogram(
    "mahilo.message.processing_time",
    description="Time taken to process messages",
    unit="ms"
)

self.message_retry_counter = self.meter.create_counter(
    "mahilo.message.retries",
    description="Number of message retries",
    unit="1"
)

self.message_failure_counter = self.meter.create_counter(
    "mahilo.message.failures",
    description="Number of message failures",
    unit="1"
)

# Queue size should be a gauge since it represents a current value
self.queue_size = self.meter.create_observable_gauge(
    "mahilo.queue.size",
    description="Current queue size",
    unit="1",
    callbacks=[lambda result: result.observe(self.metrics_data["queue_size"])]
)

# Agent metrics - this should stay as up_down_counter since we're tracking cumulative changes
self.active_agents = self.meter.create_up_down_counter(
    "mahilo.agents.active",
    description="Number of active agents",
    unit="1"
)
```

A whole bunch of events are also tracked, which you'll find a way to fetch with the next PR I make ;)