### PR TITLE
Add litellm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Above is an architecture diagram that shows the different components of the syst
 - CLI client for easy testing and interaction
 - Multiple users can connect to the same agent. In emergency situation scenarios, this means multiple police officers can connect to the same dispatcher and receive updates from the dispatcher.
 - Agents are only activated when they are needed.
+- **Multi-provider LLM support** through [LiteLLM](https://github.com/BerriAI/litellm), allowing you to use models from OpenAI, Anthropic, Azure, and more with a simple environment variable.
 
 
 ![A three-agent system where a medical advisor is talking about a public health emergency and the agent decides to call the logistics coordinator and the public communication director agents to coordinate the response to the emergency](https://github.com/wjayesh/mahilo/blob/main/assets/health_emergency1.png?raw=true)
@@ -210,6 +211,7 @@ More information on the features can be found in the [Detailed Features](#detail
 - [Flexible communication patterns: peer-to-peer and hierarchical (or centralized)](#flexible-communication-patterns-peer-to-peer-and-hierarchical-or-centralized)
 - [Flexible agent manager for handling multiple agent types](#flexible-agent-manager-for-handling-multiple-agent-names)
 - [Session management for persistent conversations](#session-management-for-persistent-conversations)
+- [Multi-provider LLM support](#multi-provider-llm-support)
 
 ### Human-in-the-Loop
 - The human-in-the-loop is implemented by having the human client connect to each agent in the system.
@@ -241,6 +243,11 @@ The BaseAgent class is designed to be subclassed for defining new agents. It com
 ### Session management for persistent conversations
 - The `Session` class is designed to manage conversation sessions for each agent. It stores the conversation history in a file for persistence.
 - The messages from the queue or the shared context are not stored to avoid duplication and redundancy.
+
+### Multi-provider LLM support
+- Mahilo uses [LiteLLM](https://github.com/BerriAI/litellm) to support a wide range of LLM providers and models.
+- You can easily switch between different models and providers by setting the `MAHILO_LLM_MODEL` environment variable in the format `provider/model`.
+- For detailed documentation, see [LLM Integration](docs/llm_integration.md).
 
 ## Contributing
 

--- a/docs/llm_integration.md
+++ b/docs/llm_integration.md
@@ -1,0 +1,69 @@
+# Multi-provider LLM Support with LiteLLM
+
+Mahilo now supports multiple LLM providers through [LiteLLM](https://github.com/BerriAI/litellm), allowing you to easily switch between different models and providers.
+
+## Configuration
+
+The LLM configuration is managed through the `LLMConfig` class in `mahilo/llm_config.py`. This class handles the setup of LiteLLM with the appropriate API keys.
+
+### Environment Variables
+
+You can configure the LLM model using the following environment variable:
+
+- `MAHILO_LLM_MODEL`: The model to use in the format `provider/model` (default: "openai/gpt-4o-mini")
+
+The provider is specified as part of the model name, following LiteLLM's convention. For example:
+- `openai/gpt-4o` for OpenAI's GPT-4o
+- `anthropic/claude-3-opus-20240229` for Anthropic's Claude
+- `azure/your-deployment-name` for Azure OpenAI
+
+### API Keys
+
+API keys for different providers can be set via environment variables:
+
+- `OPENAI_API_KEY`: For OpenAI models
+- `ANTHROPIC_API_KEY`: For Anthropic models
+- `AZURE_API_KEY` and `AZURE_API_BASE`: For Azure OpenAI models
+
+## Supported Providers
+
+LiteLLM supports a wide range of providers, including:
+
+- OpenAI
+- Anthropic
+- Azure OpenAI
+- Google AI (Gemini)
+- Cohere
+- Mistral AI
+- And many more
+
+For a complete list of supported providers, see the [LiteLLM documentation](https://docs.litellm.ai/docs/providers).
+
+## Usage
+
+The LLM configuration is automatically loaded when Mahilo starts. You don't need to make any changes to your code to use different models or providers - just set the appropriate environment variables.
+
+### Example
+
+```bash
+# Use OpenAI's GPT-4o
+export MAHILO_LLM_MODEL="openai/gpt-4o"
+export OPENAI_API_KEY="your-openai-api-key"
+
+# Use Anthropic's Claude
+export MAHILO_LLM_MODEL="anthropic/claude-3-opus-20240229"
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+
+# Use Azure OpenAI
+export MAHILO_LLM_MODEL="azure/your-deployment-name"
+export AZURE_API_KEY="your-azure-api-key"
+export AZURE_API_BASE="https://your-resource-name.openai.azure.com"
+```
+
+## Fallback Mechanism
+
+If there's an error with the specified model, Mahilo will automatically try to fall back to the default model (openai/gpt-4o-mini). This ensures that your application continues to work even if there are issues with the configured model.
+
+## Advanced Configuration
+
+For advanced configuration options, you can modify the `LLMConfig` class in `mahilo/llm_config.py`. This allows you to customize the behavior of LiteLLM, such as adding custom headers, setting timeouts, or configuring caching. 

--- a/mahilo/llm_config.py
+++ b/mahilo/llm_config.py
@@ -1,0 +1,119 @@
+import os
+from typing import Dict, List, Any, Optional
+import litellm
+from rich.console import Console
+
+console = Console()
+
+class LLMConfig:
+    """Configuration for LLM models using LiteLLM.
+    
+    This class handles the configuration of LLM models and providers,
+    allowing for easy switching between different models and providers.
+    """
+    
+    def __init__(self):
+        """Initialize the LLM configuration.
+        
+        Reads environment variables to determine which model and provider to use.
+        Falls back to defaults if not specified.
+        """
+        # Default model configuration
+        self.default_model = "gpt-4o-mini"
+        self.default_provider = "openai"
+        
+        # Read from environment variables
+        self.model = os.getenv("MAHILO_LLM_MODEL", self.default_model)
+        self.provider = os.getenv("MAHILO_LLM_PROVIDER", self.default_provider)
+        
+        # API keys and endpoints
+        self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+        self.azure_api_key = os.getenv("AZURE_API_KEY")
+        self.azure_endpoint = os.getenv("AZURE_API_BASE")
+        
+        # Set up LiteLLM with the appropriate provider
+        self._setup_litellm()
+        
+        # Log the configuration
+        self._log_config()
+    
+    def _setup_litellm(self):
+        """Configure LiteLLM with the appropriate provider and API keys."""
+        # Set the default API keys for different providers
+        if self.openai_api_key:
+            litellm.openai_key = self.openai_api_key
+        
+        if self.anthropic_api_key:
+            litellm.anthropic_key = self.anthropic_api_key
+            
+        if self.azure_api_key and self.azure_endpoint:
+            litellm.azure_key = self.azure_api_key
+            litellm.azure_endpoint = self.azure_endpoint
+    
+    def _log_config(self):
+        """Log the current LLM configuration."""
+        console.print(f"[bold blue]🤖 LLM Configuration:[/bold blue]")
+        console.print(f"  [green]▪[/green] [cyan]Provider:[/cyan] [dim]{self.provider}[/dim]")
+        console.print(f"  [green]▪[/green] [cyan]Model:[/cyan] [dim]{self.model}[/dim]")
+    
+    async def chat_completion(self, 
+                       messages: List[Dict[str, Any]], 
+                       model: Optional[str] = None,
+                       tools: Optional[List[Dict[str, Any]]] = None,
+                       tool_choice: Optional[str] = None,
+                       temperature: float = 0.7,
+                       **kwargs) -> Any:
+        """Generate a chat completion using LiteLLM.
+        
+        Args:
+            messages: List of message dictionaries with role and content
+            model: Optional model override
+            tools: Optional list of tools for function calling
+            tool_choice: Optional tool choice setting
+            temperature: Temperature for generation
+            **kwargs: Additional arguments to pass to LiteLLM
+            
+        Returns:
+            The response from the LLM
+        """
+        try:
+            # Use the specified model or fall back to the configured one
+            model_to_use = model or self.model
+            
+            # Prepare the request parameters
+            params = {
+                "model": model_to_use,
+                "messages": messages,
+                "temperature": temperature,
+                **kwargs
+            }
+            
+            # Add tools if provided
+            if tools:
+                params["tools"] = tools
+                
+            if tool_choice:
+                params["tool_choice"] = tool_choice
+            
+            # Make the API call through LiteLLM
+            response = await litellm.acompletion(**params)
+            return response
+            
+        except Exception as e:
+            console.print(f"[bold red]⛔ Error in LLM request:[/bold red] {str(e)}")
+            # If there's an error with the specified model, try falling back to the default
+            if model_to_use != self.default_model:
+                console.print(f"[yellow]⚠️ Falling back to default model: {self.default_model}[/yellow]")
+                return await self.chat_completion(
+                    messages=messages,
+                    model=self.default_model,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    temperature=temperature,
+                    **kwargs
+                )
+            raise e
+
+# Create a singleton instance
+llm_config = LLMConfig() 

--- a/mahilo/llm_config.py
+++ b/mahilo/llm_config.py
@@ -15,16 +15,14 @@ class LLMConfig:
     def __init__(self):
         """Initialize the LLM configuration.
         
-        Reads environment variables to determine which model and provider to use.
+        Reads environment variables to determine which model to use.
         Falls back to defaults if not specified.
         """
-        # Default model configuration
-        self.default_model = "gpt-4o-mini"
-        self.default_provider = "openai"
+        # Default model configuration (includes provider)
+        self.default_model = "openai/gpt-4o-mini"
         
         # Read from environment variables
         self.model = os.getenv("MAHILO_LLM_MODEL", self.default_model)
-        self.provider = os.getenv("MAHILO_LLM_PROVIDER", self.default_provider)
         
         # API keys and endpoints
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
@@ -39,7 +37,7 @@ class LLMConfig:
         self._log_config()
     
     def _setup_litellm(self):
-        """Configure LiteLLM with the appropriate provider and API keys."""
+        """Configure LiteLLM with the appropriate API keys."""
         # Set the default API keys for different providers
         if self.openai_api_key:
             litellm.openai_key = self.openai_api_key
@@ -54,7 +52,6 @@ class LLMConfig:
     def _log_config(self):
         """Log the current LLM configuration."""
         console.print(f"[bold blue]🤖 LLM Configuration:[/bold blue]")
-        console.print(f"  [green]▪[/green] [cyan]Provider:[/cyan] [dim]{self.provider}[/dim]")
         console.print(f"  [green]▪[/green] [cyan]Model:[/cyan] [dim]{self.model}[/dim]")
     
     async def chat_completion(self, 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "websockets==13.0.1",
     "python-dotenv==1.0.1",
     "pydantic",
+    "litellm>=1.30.0",
     "rich==13.9.3",
     "langgraph==0.2.60",
     "pydantic-ai==0.0.15",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.115.6
 openai>=1.59.8
+litellm>=1.30.0
 python-dotenv==1.0.1
 uvicorn==0.30.6
 websockets==13.0.1


### PR DESCRIPTION
# Multi-provider LLM Support with LiteLLM

Mahilo now supports multiple LLM providers through [LiteLLM](https://github.com/BerriAI/litellm), allowing you to easily switch between different models and providers.

## Configuration

The LLM configuration is managed through the `LLMConfig` class in `mahilo/llm_config.py`. This class handles the setup of LiteLLM with the appropriate API keys.

### Environment Variables

You can configure the LLM model using the following environment variable:

- `MAHILO_LLM_MODEL`: The model to use in the format `provider/model` (default: "openai/gpt-4o-mini")

The provider is specified as part of the model name, following LiteLLM's convention. For example:
- `openai/gpt-4o` for OpenAI's GPT-4o
- `anthropic/claude-3-opus-20240229` for Anthropic's Claude
- `azure/your-deployment-name` for Azure OpenAI


More info in the docs page about it.